### PR TITLE
Only build images which failed to pull when prefer_pull

### DIFF
--- a/tools/images_build.py
+++ b/tools/images_build.py
@@ -9,14 +9,19 @@ import subprocess
 
 from .target_find_files import find_bicep_file
 
-def images_build(target, registry, repository, tag="latest"):
+def images_build(target, registry, repository, tag="latest", services_to_build=None):
 
     assert target is not None, "Target is required"
     assert registry is not None, "Registry is required"
     if repository is None:
         repository = os.path.splitext(find_bicep_file(target))[0]
 
-    subprocess.run(["docker-compose", "build"],
+    build_command = ["docker-compose", "build"]
+    if services_to_build:
+        build_command.extend(services_to_build)
+        build_command.append("--with-dependencies")
+
+    subprocess.run(build_command,
         env={
             **os.environ,
             "TARGET": os.path.realpath(target),

--- a/tools/images_pull.py
+++ b/tools/images_pull.py
@@ -18,7 +18,7 @@ def images_pull(target, registry, repository, tag="latest"):
 
     subprocess.run(["az", "acr", "login", "--name", registry])
 
-    subprocess.run(["docker-compose", "pull"],
+    res = subprocess.run(["docker-compose", "pull"],
         env={
             **os.environ,
             "TARGET": os.path.realpath(target),
@@ -27,8 +27,13 @@ def images_pull(target, registry, repository, tag="latest"):
             "TAG": tag,
         },
         cwd=target,
-        check=True,
+        capture_output=True,
+        text=True,
     )
+    for line in res.stderr.split(os.linesep):
+        if line.strip().startswith("docker compose build"):
+            return line.split()[3:]
+    return []
 
 
 if __name__ == "__main__":

--- a/tools/target_run.py
+++ b/tools/target_run.py
@@ -32,20 +32,21 @@ def target_run_ctx(
     repository=None,
     prefer_pull=False,
 ):
-    try:
-        assert prefer_pull
-        images_pull(
+    services_to_build = None
+    if prefer_pull:
+        services_to_build = images_pull(
             target=target,
             registry=registry,
             repository=repository,
             tag=tag,
         )
-    except:
+    if not prefer_pull or services_to_build:
         images_build(
             target=target,
             registry=registry,
             repository=repository,
             tag=tag,
+            services_to_build=services_to_build,
         )
         images_push(
             target=target,


### PR DESCRIPTION
If a user uses prefer-pull, it might be because they can't build the images in their env, so only attempt to build images which failed to be pulled