### PR TITLE
Use deployment name when generating policies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,7 +85,9 @@
             "justMyCode": false,
             "envFile": "${workspaceFolder}/${input:cacitestingEnvPath}",
             "args": [
-                "${input:cacitestingTargetPath}"
+                "${input:cacitestingTargetPath}",
+                "--deployment-name",
+                "${input:cacitestingTargetName}"
             ]
         },
         {

--- a/tools/target_run.py
+++ b/tools/target_run.py
@@ -58,6 +58,7 @@ def target_run_ctx(
     if gen_policies:
         policies_gen(
             target=target,
+            deployment_name=name,
             subscription=subscription,
             resource_group=resource_group,
             registry=registry,


### PR DESCRIPTION
This is needed because elements which are enforced by policy such as environment variables and command may use it