### PR TITLE
Skip deployment if already live

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="c-aci-testing",
-    version="0.1.14",
+    version="0.1.15",
     description="Utilities for testing workflows involving Confidential ACI.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tools/aci_is_live.py
+++ b/tools/aci_is_live.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import argparse
+import json
+import os
+import subprocess
+
+
+def aci_is_live(
+    subscription,
+    resource_group,
+    name,
+):
+    res = subprocess.run(
+        [
+            "az", "deployment", "group", "show",
+            "--name", name,
+            *(["--subscription", subscription] if subscription else []),
+            "--resource-group", resource_group,
+            "--query", "properties.outputs.ids.value",
+            "-o", "tsv",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+
+    ids = [id for id in res.stdout.decode().split(os.linesep) if id]
+
+    for id in ids:
+        res = subprocess.run([
+            "az", "container", "show", "--ids", id,
+        ], stdout=subprocess.PIPE)
+        container_state = json.loads(res.stdout.decode())
+        if container_state["instanceView"]["state"] != "Running":
+            return None
+
+    return ids
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Deploy ACI for target")
+
+    # Azure Information
+    parser.add_argument(
+        "--subscription",
+        help="Azure Subscription ID",
+        default=os.environ.get("SUBSCRIPTION"),
+    )
+    parser.add_argument(
+        "--resource-group",
+        "-g",
+        help="Azure Resource Group ID",
+        default=os.environ.get("RESOURCE_GROUP"),
+    )
+
+    # Deployment Info
+    parser.add_argument("--name", "-n", help="Name of deployment", required=True)
+
+    args = parser.parse_args()
+
+    ids = aci_is_live(
+        subscription=args.subscription,
+        resource_group=args.resource_group,
+        name=args.name,
+    )
+
+    if ids:
+        print(f"Deployment resources are live: {ids}")

--- a/tools/aci_is_live.py
+++ b/tools/aci_is_live.py
@@ -23,9 +23,11 @@ def aci_is_live(
             "--query", "properties.outputs.ids.value",
             "-o", "tsv",
         ],
-        check=True,
         stdout=subprocess.PIPE,
     )
+
+    if res.returncode != 0:
+        return None
 
     ids = [id for id in res.stdout.decode().split(os.linesep) if id]
 

--- a/tools/target_run.py
+++ b/tools/target_run.py
@@ -35,7 +35,11 @@ def target_run_ctx(
     gen_policies=True,
 ):
     services_to_build = None
-    ids = aci_is_live()
+    ids = aci_is_live(
+        subscription=subscription,
+        resource_group=resource_group,
+        name=name,
+    )
     if not ids:
         if prefer_pull:
             services_to_build = images_pull(

--- a/tools/target_run.py
+++ b/tools/target_run.py
@@ -11,6 +11,7 @@ from .images_pull import images_pull
 from .images_build import images_build
 from .images_push import images_push
 from .policies_gen import policies_gen
+from .aci_is_live import aci_is_live
 from .aci_deploy import aci_deploy
 from .aci_monitor import aci_monitor
 from .aci_remove import aci_remove
@@ -34,47 +35,49 @@ def target_run_ctx(
     gen_policies=True,
 ):
     services_to_build = None
-    if prefer_pull:
-        services_to_build = images_pull(
+    ids = aci_is_live()
+    if not ids:
+        if prefer_pull:
+            services_to_build = images_pull(
+                target=target,
+                registry=registry,
+                repository=repository,
+                tag=tag,
+            )
+        if not prefer_pull or services_to_build:
+            images_build(
+                target=target,
+                registry=registry,
+                repository=repository,
+                tag=tag,
+                services_to_build=services_to_build,
+            )
+            images_push(
+                target=target,
+                registry=registry,
+                repository=repository,
+                tag=tag,
+            )
+        if gen_policies:
+            policies_gen(
+                target=target,
+                deployment_name=name,
+                subscription=subscription,
+                resource_group=resource_group,
+                registry=registry,
+                repository=repository,
+                tag=tag,
+            )
+        ids = aci_deploy(
             target=target,
-            registry=registry,
-            repository=repository,
-            tag=tag,
-        )
-    if not prefer_pull or services_to_build:
-        images_build(
-            target=target,
-            registry=registry,
-            repository=repository,
-            tag=tag,
-            services_to_build=services_to_build,
-        )
-        images_push(
-            target=target,
-            registry=registry,
-            repository=repository,
-            tag=tag,
-        )
-    if gen_policies:
-        policies_gen(
-            target=target,
-            deployment_name=name,
             subscription=subscription,
             resource_group=resource_group,
-            registry=registry,
-            repository=repository,
+            name=name,
+            location=location,
+            managed_identity=managed_identity,
             tag=tag,
+            parameters=parameters,
         )
-    ids = aci_deploy(
-        target=target,
-        subscription=subscription,
-        resource_group=resource_group,
-        name=name,
-        location=location,
-        managed_identity=managed_identity,
-        tag=tag,
-        parameters=parameters,
-    )
     try:
         yield ids
         aci_monitor(


### PR DESCRIPTION
When using target_run, if the deployment specified already exists and all container groups are still running, skip all stages of deployment

This is useful for separate deployment/test jobs in CI, and makes local iteration quick