### PR TITLE
fix: don't add params that are set in aci deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This project provides utilities for testing workflows involving Confidential ACI
 ```
 latest=$(gh release list -R microsoft/confidential-aci-testing -L 1 --json tagName --jq '.[0].tagName')
 gh release download $latest -R microsoft/confidential-aci-testing
-pip install c-aci-testing*.tar.gz
-rm c-aci-testing*.tar.gz
+pip install c_aci_testing*.tar.gz
+rm c_aci_testing*.tar.gz
 ```
 
 ### Define your Azure Environment

--- a/src/c_aci_testing/tools/aci_deploy.py
+++ b/src/c_aci_testing/tools/aci_deploy.py
@@ -27,7 +27,8 @@ def aci_deploy(
         parameters=[f"{k}='{v}'" for k, v in {
             "location": location,
             "managedIDName": managed_identity,
-        }.items()]
+        }.items()],
+        add=False,
     )
 
     # Find the bicep files


### PR DESCRIPTION
Currently params set by aci_deploy will be added if they don't exist, this can break templates which don't use default fields such as managed identity