### PR TITLE
fix: handle n spaces around equals in bicepparam

### DIFF
--- a/src/c_aci_testing/tools/aci_param_set.py
+++ b/src/c_aci_testing/tools/aci_param_set.py
@@ -33,7 +33,7 @@ def aci_param_set(
 
         biceparam_template = re.sub(f"param {key}='.*'", f"param {key}={value}", biceparam_template)
         biceparam_template = re.sub(
-            f"param {key}=\\{{.*\\}}",
+            f"param {key}\s*=\s*\\{{.*\\}}",
             f"param {key}={value}",
             biceparam_template,
             flags=re.DOTALL,


### PR DESCRIPTION
When setting a parameter in the bicep template, if the parameter has spaces around the equals we don't find it and just add a new parameter.

Update the regex to handle any number of spaces