### PR TITLE
fix: Add retry for az acr login

### DIFF
--- a/src/c_aci_testing/tools/images_pull.py
+++ b/src/c_aci_testing/tools/images_pull.py
@@ -8,6 +8,25 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
+
+
+def login_with_retry(registry: str):
+    attempts = 0
+    max_attempts = 3
+    while attempts < max_attempts:
+        try:
+            subprocess.run(["az", "acr", "login", "--name", registry], check=True)
+            return
+        except subprocess.CalledProcessError:
+            attempts += 1
+            if attempts == max_attempts:
+                print(f"Failed to login to {registry} after {max_attempts} attempts.")
+                raise
+            else:
+                sleep_s = 2 ** (attempts + 1)
+                print(f"Retrying login to {registry} in {sleep_s}s...")
+                time.sleep(sleep_s)
 
 
 def images_pull(
@@ -17,7 +36,7 @@ def images_pull(
     tag: str | None,
     **kwargs,
 ) -> list[str]:
-    subprocess.run(["az", "acr", "login", "--name", registry], check=True)
+    login_with_retry(registry)
 
     print(f"Pulling images for {registry}")
     for stderr_val in (None, subprocess.PIPE):


### PR DESCRIPTION
Improve test reliability

see e.g. https://github.com/microsoft/confidential-aci-dashboard/actions/runs/13930570239/job/38986420367#step:5:25, https://github.com/microsoft/confidential-aci-dashboard/actions/runs/13930980552/job/38987757061#step:5:24