### PR TITLE
fix: Remove unneeded emptyDir workaround

### DIFF
--- a/src/c_aci_testing/tools/policies_gen.py
+++ b/src/c_aci_testing/tools/policies_gen.py
@@ -191,11 +191,6 @@ def policies_gen(
                 if "value" not in env_var:
                     env_var["secureValue"] = ""
 
-        # Workaround for acipolicygen not supporting missing emptyDir value
-        if "volumes" in resource["properties"]:
-            for volume in resource["properties"]["volumes"]:
-                volume["emptyDir"] = {}
-
         # Derive container group ID
         container_group_id = (
             resource["name"]


### PR DESCRIPTION
Not sure if this is fixed in a recent confcom version, but not having this emptyDir property works for me, and in fact, if we include it, the policy would deny actually mounting other types of volume due to wrong source constraint (tested for azureFile).

And it's not like we can omit the emptyDir property when it is an emptyDir either:

```
{
  "status": "Failed",
  "error": {
    "code": "DeploymentFailed",
    "target": "/subscriptions/85c61f94-8912-4e82-900e-6ab44de9bdf8/resourceGroups/c-aci-dashboard/providers/Microsoft.Resources/deployments/tingmao-volume-personalsub-sa-euseuap",
    "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
    "details": [
      {
        "code": "VolumePropertyNotSpecified",
        "message": "Volume property is not specified in the volume 'volume'. Please specify one of the properties 'AzureFile,EmptyDir,Secret,GitRepo,AzureDisk'."
      }
    ]
  }
}
```