### PR TITLE
fix: explicitly say licenseType: 'Windows_Server' in vm deployment

### DIFF
--- a/src/c_aci_testing/bicep/containerplatVM.bicep
+++ b/src/c_aci_testing/bicep/containerplatVM.bicep
@@ -164,6 +164,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2022-03-01' = {
             id: vmImage
           }
     }
+    licenseType: 'Windows_Server'
     networkProfile: {
       networkInterfaces: [
         {


### PR DESCRIPTION
Not sure if it makes a difference for 1p, but it's technically the correct thing to do