### PR TITLE
feat: Basic VN2 support with refactored ARM parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
 ]
 requires-python = ">=3.8.1"
 dynamic = ["version"]
+dependencies = [
+    "pyyaml~=6.0.2"
+]
 
 [project.scripts]
 c-aci-testing = "c_aci_testing.main:main"

--- a/src/c_aci_testing/args/parameters/yaml_path.py
+++ b/src/c_aci_testing/args/parameters/yaml_path.py
@@ -1,0 +1,16 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def parse_yaml_path(parser: ArgumentParser):
+    parser.add_argument(
+        "--yaml-path",
+        type=str,
+        help="Path to the YAML file to generate. Default is workload_name.yaml",
+    )

--- a/src/c_aci_testing/args/parser.py
+++ b/src/c_aci_testing/args/parser.py
@@ -67,7 +67,7 @@ def parse_command():
     args = arg_parser.parse_args()
 
     missing_args = []
-    exceptions = ["repository", "tag", "infrastructure_svn"]
+    exceptions = ["repository", "tag", "infrastructure_svn", "yaml_path"]
     for key, value in vars(args).items():
         if value is None and key not in exceptions:
             missing_args.append(key)

--- a/src/c_aci_testing/args/parser.py
+++ b/src/c_aci_testing/args/parser.py
@@ -18,6 +18,7 @@ from .subparsers.policies import subparse_policies
 from .subparsers.target import subparse_target
 from .subparsers.vm import subparse_vm
 from .subparsers.vscode import subparse_vscode
+from .subparsers.vn2 import subparse_vn2
 
 
 def parse_command():
@@ -36,6 +37,7 @@ def parse_command():
     subparser.add_parser("target")
     subparser.add_parser("vm")
     subparser.add_parser("vscode")
+    subparser.add_parser("vn2")
 
     args, _ = arg_parser.parse_known_args()
 
@@ -57,6 +59,8 @@ def parse_command():
         subparse_vm(subparser.choices["vm"])
     elif args.command == "vscode":
         subparse_vscode(subparser.choices["vscode"])
+    elif args.command == "vn2":
+        subparse_vn2(subparser.choices["vn2"])
     else:
         raise argparse.ArgumentError(None, "command is required")
 

--- a/src/c_aci_testing/args/subparsers/vn2.py
+++ b/src/c_aci_testing/args/subparsers/vn2.py
@@ -1,0 +1,39 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+
+from ..parameters.deployment_name import parse_deployment_name
+from ..parameters.managed_identity import parse_managed_identity
+from ..parameters.resource_group import parse_resource_group
+from ..parameters.subscription import parse_subscription
+from ..parameters.target_path import parse_target_path
+from ..parameters.registry import parse_registry
+from ..parameters.repository import parse_repository
+from ..parameters.tag import parse_tag
+
+
+def subparse_vn2(vm: argparse.ArgumentParser):
+
+    vn2_subparser = vm.add_subparsers(dest="vn2_command", required=True)
+
+    generate_yaml = vn2_subparser.add_parser("generate_yaml")
+    parse_deployment_name(generate_yaml)
+    parse_managed_identity(generate_yaml)
+    parse_target_path(generate_yaml)
+    generate_yaml.add_argument("output_yaml_path", type=str)
+    parse_subscription(generate_yaml)
+    parse_resource_group(generate_yaml)
+    parse_registry(generate_yaml)
+    parse_repository(generate_yaml)
+    parse_tag(generate_yaml)
+    generate_yaml.add_argument(
+        "--replicas",
+        type=int,
+        help="Number of replicas in the deployment template",
+        default=1,
+    )

--- a/src/c_aci_testing/args/subparsers/vn2.py
+++ b/src/c_aci_testing/args/subparsers/vn2.py
@@ -15,6 +15,11 @@ from ..parameters.target_path import parse_target_path
 from ..parameters.registry import parse_registry
 from ..parameters.repository import parse_repository
 from ..parameters.tag import parse_tag
+from ..parameters.yaml_path import parse_yaml_path
+from ..parameters.policy_type import parse_policy_type
+from ..parameters.fragments_json import parse_fragments_json
+from ..parameters.infrastructure_svn import parse_infrastructure_svn
+from ..parameters.follow import parse_follow
 
 
 def subparse_vn2(vm: argparse.ArgumentParser):
@@ -25,15 +30,37 @@ def subparse_vn2(vm: argparse.ArgumentParser):
     parse_deployment_name(generate_yaml)
     parse_managed_identity(generate_yaml)
     parse_target_path(generate_yaml)
-    generate_yaml.add_argument("output_yaml_path", type=str)
     parse_subscription(generate_yaml)
     parse_resource_group(generate_yaml)
     parse_registry(generate_yaml)
     parse_repository(generate_yaml)
     parse_tag(generate_yaml)
+    parse_yaml_path(generate_yaml)
     generate_yaml.add_argument(
         "--replicas",
         type=int,
         help="Number of replicas in the deployment template",
         default=1,
     )
+
+    # Deploy command
+    deploy = vn2_subparser.add_parser("deploy")
+    parse_target_path(deploy)
+    parse_yaml_path(deploy)
+
+    # Logs command
+    logs = vn2_subparser.add_parser("logs")
+    parse_deployment_name(logs)
+    parse_follow(logs)
+
+    # Remove command
+    remove = vn2_subparser.add_parser("remove")
+    parse_deployment_name(remove)
+
+    # Policygen command
+    policygen = vn2_subparser.add_parser("policygen")
+    parse_target_path(policygen)
+    parse_yaml_path(policygen)
+    parse_policy_type(policygen)
+    parse_fragments_json(policygen)
+    parse_infrastructure_svn(policygen)

--- a/src/c_aci_testing/args/subparsers/vn2.py
+++ b/src/c_aci_testing/args/subparsers/vn2.py
@@ -64,3 +64,6 @@ def subparse_vn2(vm: argparse.ArgumentParser):
     parse_policy_type(policygen)
     parse_fragments_json(policygen)
     parse_infrastructure_svn(policygen)
+
+    create_pull_secret = vn2_subparser.add_parser("create_pull_secret")
+    parse_registry(create_pull_secret)

--- a/src/c_aci_testing/args/subparsers/vn2.py
+++ b/src/c_aci_testing/args/subparsers/vn2.py
@@ -65,5 +65,15 @@ def subparse_vn2(vm: argparse.ArgumentParser):
     parse_fragments_json(policygen)
     parse_infrastructure_svn(policygen)
 
+    # Get-ip command
+    get_ip = vn2_subparser.add_parser("get-ip")
+    parse_deployment_name(get_ip)
+    get_ip.add_argument(
+        "--timeout",
+        type=int,
+        help="Timeout in seconds to wait for the service to be ready",
+        default=300,
+    )
+
     create_pull_secret = vn2_subparser.add_parser("create_pull_secret")
     parse_registry(create_pull_secret)

--- a/src/c_aci_testing/main.py
+++ b/src/c_aci_testing/main.py
@@ -214,6 +214,13 @@ def main():
         else:
             print(f"github command: {args.github_command} not recognised")
 
+    elif args.command == "vn2":
+
+        if args.vn2_command == "generate_yaml":
+            from .tools.vn2_generate_yaml import vn2_generate_yaml
+
+            vn2_generate_yaml(**vars(args))
+
     else:
         print(f"Command: {args.command} not recognised")
 

--- a/src/c_aci_testing/main.py
+++ b/src/c_aci_testing/main.py
@@ -241,6 +241,11 @@ def main():
 
             vn2_policygen(**vars(args))
 
+        elif args.vn2_command == "create_pull_secret":
+            from .tools.vn2_create_pull_secret import vn2_create_pull_secret
+
+            vn2_create_pull_secret(**vars(args))
+
         else:
             print(f"vn2 command: {args.vn2_command} not recognised")
 

--- a/src/c_aci_testing/main.py
+++ b/src/c_aci_testing/main.py
@@ -246,6 +246,11 @@ def main():
 
             vn2_create_pull_secret(**vars(args))
 
+        elif args.vn2_command == "get-ip":
+            from .tools.vn2_get_ip import vn2_get_ip
+
+            vn2_get_ip(**vars(args))
+
         else:
             print(f"vn2 command: {args.vn2_command} not recognised")
 

--- a/src/c_aci_testing/main.py
+++ b/src/c_aci_testing/main.py
@@ -221,6 +221,29 @@ def main():
 
             vn2_generate_yaml(**vars(args))
 
+        elif args.vn2_command == "deploy":
+            from .tools.vn2_deploy import vn2_deploy
+
+            vn2_deploy(**vars(args))
+
+        elif args.vn2_command == "logs":
+            from .tools.vn2_logs import vn2_logs
+
+            vn2_logs(**vars(args))
+
+        elif args.vn2_command == "remove":
+            from .tools.vn2_remove import vn2_remove
+
+            vn2_remove(**vars(args))
+
+        elif args.vn2_command == "policygen":
+            from .tools.vn2_policygen import vn2_policygen
+
+            vn2_policygen(**vars(args))
+
+        else:
+            print(f"vn2 command: {args.vn2_command} not recognised")
+
     else:
         print(f"Command: {args.command} not recognised")
 

--- a/src/c_aci_testing/templates/target/example.bicepparam
+++ b/src/c_aci_testing/templates/target/example.bicepparam
@@ -7,5 +7,7 @@ param tag=''
 
 // Deployment info
 param location=''
-param ccePolicies={}
+param ccePolicies={
+  example: ''
+}
 param managedIDName=''

--- a/src/c_aci_testing/tools/aci_param_set.py
+++ b/src/c_aci_testing/tools/aci_param_set.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import os
 import re
 
+from c_aci_testing.utils.find_bicep import find_bicep_files
+
 
 def aci_param_set(
     target_path: str,
@@ -16,19 +18,10 @@ def aci_param_set(
     add: bool = True,
     **kwargs,
 ):
-    # Find the bicep param file
-    biceparam_file_path = None
-    bicepparam_files = [file for file in os.listdir(target_path) if file.endswith(".bicepparam")]
-
-    if not bicepparam_files:
-        raise FileNotFoundError("No .bicepparam file found in the target directory.")
-    elif len(bicepparam_files) > 1:
-        raise ValueError("Multiple .bicepparam files found in the target directory.")
-    else:
-        biceparam_file_path = bicepparam_files[0]
+    _, bicepparam_file_path = find_bicep_files(target_path)
 
     # Load the param file
-    with open(os.path.join(target_path, biceparam_file_path), encoding="utf-8") as f:
+    with open(os.path.join(target_path, bicepparam_file_path), encoding="utf-8") as f:
         biceparam_content = f.read()
 
     # Set parameters
@@ -90,5 +83,5 @@ def aci_param_set(
             biceparam_content += f"{os.linesep}{param_line}"
 
     # Save the new file
-    with open(os.path.join(target_path, biceparam_file_path), "w", encoding="utf-8") as f:
+    with open(os.path.join(target_path, bicepparam_file_path), "w", encoding="utf-8") as f:
         f.write(biceparam_content)

--- a/src/c_aci_testing/tools/images_pull.py
+++ b/src/c_aci_testing/tools/images_pull.py
@@ -8,25 +8,8 @@ from __future__ import annotations
 
 import os
 import subprocess
-import time
 
-
-def login_with_retry(registry: str):
-    attempts = 0
-    max_attempts = 3
-    while attempts < max_attempts:
-        try:
-            subprocess.run(["az", "acr", "login", "--name", registry], check=True)
-            return
-        except subprocess.CalledProcessError:
-            attempts += 1
-            if attempts == max_attempts:
-                print(f"Failed to login to {registry} after {max_attempts} attempts.")
-                raise
-            else:
-                sleep_s = 2 ** (attempts + 1)
-                print(f"Retrying login to {registry} in {sleep_s}s...")
-                time.sleep(sleep_s)
+from c_aci_testing.utils.acr import login_with_retry, strip_acr_suffix
 
 
 def images_pull(
@@ -36,7 +19,7 @@ def images_pull(
     tag: str | None,
     **kwargs,
 ) -> list[str]:
-    if "." not in registry or registry.endswith(".azurecr.io"):
+    if strip_acr_suffix(registry):  # function returns None if not ACR
         login_with_retry(registry)
 
     print(f"Pulling images for {registry}")

--- a/src/c_aci_testing/tools/policies_gen.py
+++ b/src/c_aci_testing/tools/policies_gen.py
@@ -15,79 +15,21 @@ import subprocess
 import tempfile
 import shutil
 import sys
+import tempfile
 
 from .aci_param_set import aci_param_set
+from c_aci_testing.utils.parse_bicep import (
+    find_bicep_files,
+    arm_template_for_each_container_group_with_fixup,
+    parse_bicep,
+)
 
-
-def resolve_arm_functions(arm_template_str, resource_group, subscription, deployment_name):
-
-    # Handle constants
-    for constant, value in [
-        ("resourceGroup().name", resource_group),
-        ("subscription().subscriptionId", subscription),
-        ("deployment().name", deployment_name),
-    ]:
-        arm_template_str = arm_template_str.replace(constant, value)
-
-    # Remove the square brackets which denote functions in ARM templates
-    # since they will be resolved. Do it here so parameters are correctly resolved.
-    arm_template_lines = arm_template_str.split("\\n")
-    for idx, line in enumerate(arm_template_lines):
-        arm_template_lines[idx] = re.sub(r'\\"\[(.*?)\]\\"', r"\"\1\"", line)
-    arm_template_str = "\\n".join(arm_template_lines)
-    arm_template_dict = json.loads(json.loads(arm_template_str)["templateJson"])
-
-    # Handle parameters function
-    parameters_dict = {
-        key: value["value"]
-        for key, value in json.loads(json.loads(arm_template_str)["parametersJson"])["parameters"].items()
-    }
-    parameters = {key: definition.get("defaultValue") for key, definition in arm_template_dict["parameters"].items()}
-    parameters.update(parameters_dict)
-    for key, value in parameters.items():
-        arm_template_str = re.sub(
-            f"parameters\\('{key}'\\)",
-            str(value),
-            arm_template_str,
-        )
-
-    # Handle empty function
-    arm_template_lines = arm_template_str.split("\\n")
-    for idx, line in enumerate(arm_template_lines):
-        for match in re.findall(r"empty\((.*?)\)", line):
-            arm_template_lines[idx] = line.replace(
-                f"empty({match})",
-                "true" if match == "" else "false",
-            )
-            line = arm_template_lines[idx]
-    arm_template_str = "\\n".join(arm_template_lines)
-
-    # Handle if function
-    arm_template_lines = arm_template_str.split("\\n")
-    for idx, line in enumerate(arm_template_lines):
-        for condition, if_true, if_false in re.findall(
-            r"if\((.*?)\, (.*?)\, (.*?)\)",
-            line,
-        ):
-            arm_template_lines[idx] = line.replace(
-                f"if({condition}, {if_true}, {if_false})",
-                f"{if_true}" if condition == "true" else f"{if_false}",
-            )
-            line = arm_template_lines[idx]
-    arm_template_str = "\\n".join(arm_template_lines)
-
-    # Handle format function
-    arm_template_lines = arm_template_str.split("\\n")
-    for idx, line in enumerate(arm_template_lines):
-        for format_string, inputs in re.findall(r"format\((.*?)\, (.*?)\)", line):
-            inputs_list = [i.strip("'") for i in inputs.split(", ")]
-            arm_template_lines[idx] = line.replace(
-                f"format({format_string}, {inputs})",
-                format_string.format(*inputs_list).strip("'"),
-            )
-    arm_template_str = "\\n".join(arm_template_lines)
-
-    return json.loads(json.loads(arm_template_str)["templateJson"])
+ALLOW_ALL_POLICY_REGO_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "templates",
+    "allow_all_policy.rego",
+)
 
 
 def policies_gen(
@@ -112,20 +54,7 @@ def policies_gen(
     if policy_type != "generated":
         print("This should not be used in real environments")
 
-    bicep_file_path = None
-    bicepparam_file_path = None
-
-    # Find the bicep files
-    for file in os.listdir(target_path):
-        if file.endswith(".bicep"):
-            bicep_file_path = os.path.join(target_path, file)
-        elif file.endswith(".bicepparam"):
-            bicepparam_file_path = os.path.join(target_path, file)
-
-    if not bicep_file_path:
-        raise FileNotFoundError(f"No bicep file found in {target_path}")
-    if not bicepparam_file_path:
-        raise FileNotFoundError(f"No bicepparam file found in {target_path}")
+    bicep_file_path, _ = find_bicep_files(target_path)
 
     # Check if a policy needs to be set
     with open(bicep_file_path) as f:
@@ -134,70 +63,19 @@ def policies_gen(
         print("This template doesn't use generated policies, skipping policy gen")
         return
 
-    # Set required parameters in bicep param file
-    aci_param_set(
-        target_path,
-        parameters=[
-            f"{k}='{v}'"
-            for k, v in {
-                "registry": registry,
-                "repository": repository or "",
-                "tag": tag or "",
-            }.items()
-        ],
-        add=False,  # If the user removed a field, don't re-add it
+    arm_template_json = parse_bicep(
+        target_path, subscription, resource_group, deployment_name, registry, repository, tag
     )
 
     policies = {}
-    # Deliberately does not delete this directory if it fails
-    arm_template_dir = tempfile.mkdtemp()
-    print(f"Placing ARM templates in {arm_template_dir}")
 
-    print("Converting bicep files to an ARM template", flush=True)
-    sys.stderr.flush()
-    res = subprocess.run(
-        [
-            "az",
-            "bicep",
-            "build-params",
-            "--file",
-            bicepparam_file_path,
-            "--stdout",
-        ],
-        check=True,
-        stdout=subprocess.PIPE,
-    )
-    arm_template_json = resolve_arm_functions(
-        res.stdout.decode(),
-        resource_group=resource_group,
-        subscription=subscription,
-        deployment_name=deployment_name,
-    )
-
-    for resource in arm_template_json["resources"]:
-
-        # Only handle container groups
-        if resource["type"] not in (
-            "Microsoft.ContainerInstance/containerGroups",
-            "Microsoft.ContainerInstance/containerGroupProfiles",
-        ):
-            continue
-
-        # Only handle confidential container groups
-        if resource["properties"].get("sku", "Standard") != "Confidential":
-            continue
-
-        # Workaround for acipolicygen not supporting empty environment variables
-        for container in resource["properties"]["containers"]:
-            for env_var in container["properties"].get("environmentVariables", []):
-                if "value" in env_var and env_var["value"] == "":
-                    del env_var["value"]
-                if "value" not in env_var:
-                    env_var["secureValue"] = ""
-
+    for container_group, containers in arm_template_for_each_container_group_with_fixup(
+        arm_template_json,
+    ):
         # Derive container group ID
+        # This is used in the ccePolicies object.
         container_group_id = (
-            resource["name"]
+            container_group["name"]
             .replace(
                 deployment_name,
                 pathlib.Path(bicep_file_path).stem,
@@ -205,21 +83,19 @@ def policies_gen(
             .replace("-", "_")
         )
 
-        allow_all_path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "templates",
-            "allow_all_policy.rego",
-        )
+        # Only handle confidential container groups
+        if container_group["properties"].get("sku", "Standard") != "Confidential":
+            continue
+
         if policy_type == "allow_all":
-            with open(allow_all_path, encoding="utf-8") as policy_file:
+            with open(ALLOW_ALL_POLICY_REGO_PATH, encoding="utf-8") as policy_file:
                 policy = policy_file.read()
         else:
-
-            # Write the resource to an ARM template file
-            arm_template_path = os.path.join(arm_template_dir, f"arm_{container_group_id}.json")
-            with open(arm_template_path, "w", encoding="utf-8") as file:
-                json.dump({"resources": [resource]}, file, indent=2)
+            # Write this container group to an ARM template file
+            # Don't remove it unless policy gen worked
+            tmp_arm_template_path = tempfile.mktemp(suffix=".json")
+            with open(tmp_arm_template_path, "w", encoding="utf-8") as file:
+                json.dump({"resources": [container_group]}, file, indent=2)
 
             print("Calling acipolicygen and saving policy to file")
             subprocess.run(["az", "extension", "add", "--name", "confcom", "--yes"], check=True)
@@ -228,7 +104,7 @@ def policies_gen(
                 "confcom",
                 "acipolicygen",
                 "-a",
-                arm_template_path,
+                tmp_arm_template_path,
                 "--outraw-pretty-print",
                 *(["--debug-mode"] if policy_type == "debug" else []),
                 *(["--include-fragments", "--fragments-json", fragments_json] if fragments_json else []),
@@ -242,6 +118,7 @@ def policies_gen(
                 stdout=subprocess.PIPE,
             )
             policy = res.stdout.decode()
+            os.remove(tmp_arm_template_path)
 
         with open(os.path.join(target_path, f"policy_{container_group_id}.rego"), "w") as file:
             file.write(policy)
@@ -257,6 +134,3 @@ def policies_gen(
             + "\n}"
         ],
     )
-
-    print(f"Removing {arm_template_dir}")
-    shutil.rmtree(arm_template_dir)

--- a/src/c_aci_testing/tools/vn2_create_pull_secret.py
+++ b/src/c_aci_testing/tools/vn2_create_pull_secret.py
@@ -1,0 +1,65 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from c_aci_testing.utils.acr import get_acr_token, strip_acr_suffix, azurecr_io_suffix
+
+
+def get_pull_secret_name(registry: str) -> str | None:
+    registry_name = strip_acr_suffix(registry)
+    if not registry_name:
+        return None
+
+    return f"acr-auth-{registry_name}"
+
+
+def vn2_create_pull_secret(registry: str, **kwargs):
+    """
+    Creates a short-lived token and use it as a pull secret for the given ACR.
+    """
+
+    registry_name = strip_acr_suffix(registry)
+    if not registry_name:
+        print(f"Skipping pull secret creation for {registry} as it is not an ACR.")
+        return
+
+    registry = f"{registry_name}{azurecr_io_suffix}"
+    print(f"Creating pull secret for {registry}...", flush=True)
+    username = "00000000-0000-0000-0000-000000000000"
+    password = get_acr_token(registry)
+    pull_secret_name = get_pull_secret_name(registry)
+    assert pull_secret_name
+
+    try:
+        subprocess.run(
+            ["kubectl", "delete", "secret", pull_secret_name],
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        pass
+
+    try:
+        subprocess.run(
+            [
+                "kubectl",
+                "create",
+                "secret",
+                "docker-registry",
+                pull_secret_name,
+                f"--docker-server={registry}",
+                f"--docker-username={username}",
+                f"--docker-password={password}",
+            ],
+            stdout=subprocess.DEVNULL,
+            check=True
+        )
+    except subprocess.CalledProcessError as e:
+        # don't expose the token to console
+        print(f"Failed to create pull secret for {registry}", file=sys.stderr, flush=True)

--- a/src/c_aci_testing/tools/vn2_deploy.py
+++ b/src/c_aci_testing/tools/vn2_deploy.py
@@ -1,0 +1,168 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+import subprocess
+import time
+import json
+import yaml
+import sys
+import os
+import re
+
+from c_aci_testing.utils.run_cmd import run_cmd
+from c_aci_testing.utils.find_bicep import find_bicep_files
+
+
+def vn2_deploy(target_path: str, yaml_path: str, **kwargs):
+    """
+    Deploy a VN2 application using kubectl apply with the provided YAML file.
+    This function also checks that the pods are running correctly after deployment.
+    """
+
+    if not yaml_path:
+        bicep_file_path, _ = find_bicep_files(target_path)
+        bicep_file_name = re.sub(r"\.bicep$", "", os.path.basename(bicep_file_path))
+        if not yaml_path:
+            yaml_path = os.path.join(target_path, f"{bicep_file_name}.yaml")
+
+    # Load YAML file to get deployment information
+    with open(yaml_path, "r") as f:
+        yaml_content = f.read()
+
+    yaml_data = yaml.safe_load(yaml_content)
+    deployment_name = yaml_data["metadata"]["name"]
+    if not deployment_name:
+        print(f"Failed to get deployment name from {yaml_path}")
+        sys.exit(1)
+
+    env_dep_name = os.getenv("DEPLOYMENT_NAME")
+    if env_dep_name is not None and env_dep_name != deployment_name:
+        raise ValueError(
+            "Refusing to continue as DEPLOYMENT_NAME environment variable is inconsistent with the deployment name in the YAML file.\n"
+            + "This is likely unintentional.\n"
+            + "Run c-aci-testing vn2 generate_yaml again."
+        )
+
+    label_selector_obj = yaml_data["spec"]["selector"]["matchLabels"]
+    label_selector = ",".join([f"{k}={v}" for k, v in label_selector_obj.items()])
+    replicas = yaml_data["spec"].get("replicas")
+    if not replicas:
+        print(f"Failed to get number of replicas from {yaml_path}")
+        sys.exit(1)
+
+    print(f"Deployment name: {deployment_name}")
+    print(f"Label selector: {label_selector}")
+    print(f"Number of replicas: {replicas}")
+
+    # Deploy the deployment from the YAML template
+    run_cmd(["kubectl", "apply", "-f", yaml_path], consume_stdout=False)
+
+    # Wait for all pods of the deployment to be in Running state (max 15 minutes)
+    print("Waiting for pods to be in Running state...")
+    timeout = time.time() + 900  # 15 minutes
+
+    seen_container_ids_for_pod = {}
+    failed_container_ids = set()
+    all_container_ids = set()
+
+    def pod_print_conditions(pod):
+        conditions = pod.get("status", {}).get("conditions", [])
+        all_condition_types = [
+            condition.get("type", "???") for condition in sorted(conditions, key=lambda x: x.get("lastTransitionTime"))
+        ]
+        print(f"  Conditions: {', '.join(all_condition_types)}")
+
+    def check_pod_containers(pod):
+        """Check container status and track container IDs to detect restarts."""
+        nonlocal seen_container_ids_for_pod
+        nonlocal failed_container_ids
+        nonlocal all_container_ids
+
+        pod_name = pod["metadata"]["name"]
+        pod_container_ids = set()
+        has_issue = False
+        for container in pod.get("status", {}).get("containerStatuses", []):
+            container_id = container.get("containerID")
+            container_name = container.get("name", "???")
+            image_id = container.get("imageID", "???")
+            restart_count = container.get("restartCount", 0)
+            if not container_id:
+                print(
+                    f"  !: Container ID not found for container {container_name} in pod {pod_name}. Pod being restarted?"
+                )
+                continue
+            pod_container_ids.add(container_id)
+            all_container_ids.add(container_id)
+            print(f"  Container {container_name}:")
+            print(f"    ID: {container_id}")
+            print(f"    Image ID: {image_id}")
+            print(f"    Restart Count: {restart_count}")
+            if restart_count > 0:
+                print(f"    !: Container {container_name} has restarted {restart_count} times!")
+                has_issue = True
+        if pod_name in seen_container_ids_for_pod:
+            for container_id in seen_container_ids_for_pod[pod_name]:
+                if container_id not in pod_container_ids:
+                    print(
+                        f"    !: Container ID {container_id}, which appeared in a previous check of pod {pod_name}, has now disappeared"
+                    )
+                    failed_container_ids.add(container_id)
+        if pod_container_ids:
+            seen_container_ids_for_pod[pod_name] = pod_container_ids
+        return has_issue
+
+    nb_pods_running = 0
+
+    while time.time() < timeout:
+        pods_json = run_cmd(["kubectl", "get", "pods", "-l", label_selector, "-o", "json"], retries=2)
+        assert pods_json
+        pods_data = json.loads(pods_json)
+        if not pods_data.get("items"):
+            print("No pods created yet.")
+            time.sleep(5)
+            continue
+
+        has_issue = False
+        nb_pods_running = 0
+        for pod in pods_data["items"]:
+            print(f"Pod {pod['metadata']['name']} status: {pod['status']['phase']}")
+            pod_print_conditions(pod)
+            if pod.get("status", {}).get("phase") == "Running":
+                nb_pods_running += 1
+                if check_pod_containers(pod):
+                    print(f"ERROR: Issue detected for pod {pod['metadata']['name']}. Pod info dump follows:")
+                    subprocess.run(
+                        ["kubectl", "describe", "pod", pod["metadata"]["name"]],
+                        check=True,
+                    )
+                    has_issue = True
+        if has_issue:
+            print("Exiting due to issues detected during startup.")
+            sys.exit(1)
+        if nb_pods_running == replicas:
+            print("All pods are running now.")
+            break
+        if nb_pods_running > replicas:
+            print(f"Error: More pods running ({nb_pods_running}) than expected ({replicas}).")
+            sys.exit(1)
+
+        print("Waiting for all pods to be running...")
+        time.sleep(5)
+
+    if nb_pods_running < replicas:
+        print("Timeout reached: not all pods are Running.")
+        sys.exit(1)
+
+    # Final check for any failed containers that may have been replaced
+    if failed_container_ids:
+        print("ERROR: No restart count > 0 on any pods, but we have observed container IDs that have disappeared.")
+        for container_id in failed_container_ids:
+            print(f"  Container ID: {container_id}")
+        print("Search in earlier logs for more information.")
+        sys.exit(1)
+
+    print(f"VN2 deployment successful: {deployment_name}")
+    print("All pods are running. You can monitor them by using the 'vn2 logs' command.")

--- a/src/c_aci_testing/tools/vn2_deploy.py
+++ b/src/c_aci_testing/tools/vn2_deploy.py
@@ -32,7 +32,15 @@ def vn2_deploy(target_path: str, yaml_path: str, **kwargs):
     with open(yaml_path, "r") as f:
         yaml_content = f.read()
 
-    yaml_data = yaml.safe_load(yaml_content)
+    yaml_data_all = yaml.safe_load_all(yaml_content)
+    all_deployments = [d for d in yaml_data_all if d.get("kind") == "Deployment"]
+    if not all_deployments:
+        print(f"No deployments found in {yaml_path}")
+        sys.exit(1)
+    if len(all_deployments) > 1:
+        print(f"Multiple deployments found in {yaml_path}, which is not supported.")
+        sys.exit(1)
+    yaml_data = all_deployments[0]
     deployment_name = yaml_data["metadata"]["name"]
     if not deployment_name:
         print(f"Failed to get deployment name from {yaml_path}")

--- a/src/c_aci_testing/tools/vn2_deploy.py
+++ b/src/c_aci_testing/tools/vn2_deploy.py
@@ -53,6 +53,13 @@ def vn2_deploy(target_path: str, yaml_path: str, **kwargs):
         print(f"Failed to get number of replicas from {yaml_path}")
         sys.exit(1)
 
+    annotations = yaml_data["spec"]["template"]["metadata"].get("annotations", {})
+    if not annotations.get("microsoft.containerinstance.virtualnode.ccepolicy", ""):
+        raise ValueError(
+            "YAML does not have a ccepolicy, which will result in non-confidential VN2. Refusing to continue.\n"
+            + "Run `c-aci-testing vn2 policygen .` to populate the policy."
+        )
+
     print(f"Deployment name: {deployment_name}")
     print(f"Label selector: {label_selector}")
     print(f"Number of replicas: {replicas}")

--- a/src/c_aci_testing/tools/vn2_generate_yaml.py
+++ b/src/c_aci_testing/tools/vn2_generate_yaml.py
@@ -1,0 +1,155 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import yaml
+
+from c_aci_testing.utils.parse_bicep import parse_bicep, arm_template_for_each_container_group
+from c_aci_testing.utils.find_bicep import find_bicep_files
+
+
+def generate_vn2_yaml(
+    target_path: str,
+    subscription: str,
+    resource_group: str,
+    deployment_name: str,
+    managed_identity: str,
+    registry: str,
+    repository: str,
+    tag: str,
+    replicas: int,
+) -> str:
+    bicep_file_path, _ = find_bicep_files(target_path)
+
+    arm_template_json = parse_bicep(
+        target_path,
+        subscription,
+        resource_group,
+        deployment_name,
+        registry,
+        repository,
+        tag,
+    )
+
+    annotations = {}
+    containers = []
+
+    template_spec = {
+        "containers": containers,
+        "nodeSelector": {"virtualization": "virtualnode2"},
+        "tolerations": [{"key": "virtual-kubelet.io/provider", "operator": "Exists", "effect": "NoSchedule"}],
+    }
+
+    yaml_body = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": deployment_name,
+        },
+        "spec": {
+            "replicas": replicas,
+            "selector": {
+                "matchLabels": {
+                    "app": deployment_name,
+                },
+            },
+            "template": {
+                "metadata": {
+                    "labels": {
+                        "app": deployment_name,
+                    },
+                    "annotations": annotations,
+                },
+                "spec": template_spec,
+            },
+        },
+    }
+
+    container_groups = list(arm_template_for_each_container_group(arm_template_json))
+
+    if not container_groups:
+        raise ValueError("No container groups found in the ARM template")
+    if len(container_groups) > 1:
+        # To avoid problems with create_vn2_deployment_checked.py
+        raise ValueError("This does not support multiple container groups yet")
+
+    container_group, arm_containers = container_groups[0]
+
+    annotations["microsoft.containerinstance.virtualnode.ccepolicy"] = (
+        container_group["properties"].get("confidentialComputeProperties", {}).get("ccePolicy", "")
+    )
+    if "zones" in container_group:
+        annotations["microsoft.containerinstance.virtualnode.zones"] = ",".join(container_group["zones"])
+
+    identity = container_group.get("identity", {})
+    if "UserAssigned" in identity.get("type", ""):
+        annotations["microsoft.containerinstance.virtualnode.identity"] = list(
+            identity["userAssignedIdentities"].keys()
+        )[0]
+
+    if "subnetIds" in container_group["properties"]:
+        armSubnetIds = container_group["properties"]["subnetIds"]
+        if len(armSubnetIds) > 1:
+            raise ValueError("VN2 does not support multiple subnets")
+        annotations["microsoft.containerinstance.virtualnode.subnets.primary"] = armSubnetIds[0]["id"]
+
+    for arm_container in arm_containers:
+        props = arm_container.get("properties", {})
+
+        container_def = {"name": arm_container.get("name"), "image": props.get("image")}
+        containers.append(container_def)
+
+        resources = props.get("resources", {}).get("requests", {})
+        container_def["resources"] = {"requests": {"cpu": resources.get("cpu"), "memory": resources.get("memoryInGB")}}
+
+        ports = props.get("ports", [])
+        if ports:
+            container_def["ports"] = [{"containerPort": port.get("port")} for port in ports]
+
+        env = props.get("environmentVariables", [])
+        if env:
+            container_def["env"] = [
+                {"name": var.get("name"), "value": var.get("value", var.get("secureValue"))} for var in env
+            ]
+
+        if "command" in props:
+            container_def["command"] = props["command"]
+
+    yaml_string = yaml.dump(yaml_body, sort_keys=False)
+    return yaml_string
+
+
+def vn2_generate_yaml(
+    target_path: str,
+    output_yaml_path: str,
+    subscription: str,
+    resource_group: str,
+    deployment_name: str,
+    managed_identity: str,
+    registry: str,
+    repository: str,
+    tag: str,
+    replicas: int,
+    **kwargs,
+):
+    yaml_str = generate_vn2_yaml(
+        target_path,
+        subscription,
+        resource_group,
+        deployment_name,
+        managed_identity,
+        registry,
+        repository,
+        tag,
+        replicas,
+    )
+
+    # Write the YAML to the output file
+    with open(output_yaml_path, "wt") as f:
+        f.write(yaml_str)

--- a/src/c_aci_testing/tools/vn2_generate_yaml.py
+++ b/src/c_aci_testing/tools/vn2_generate_yaml.py
@@ -14,6 +14,7 @@ import re
 from c_aci_testing.utils.parse_bicep import parse_bicep, arm_template_for_each_container_group
 from c_aci_testing.utils.find_bicep import find_bicep_files
 from c_aci_testing.tools.aci_param_set import aci_param_set
+from .vn2_create_pull_secret import get_pull_secret_name, vn2_create_pull_secret
 
 
 def vn2_generate_yaml(
@@ -138,6 +139,13 @@ def vn2_generate_yaml(
 
         if "command" in props:
             container_def["command"] = props["command"]
+
+        if registry:
+            secret_name = get_pull_secret_name(registry)
+            if secret_name:
+                template_spec["imagePullSecrets"] = [{"name": secret_name}]
+                print(f"Creating short-lived pull secret {secret_name}", flush=True)
+                vn2_create_pull_secret(registry)
 
     yaml_str = yaml.dump(yaml_body, sort_keys=False)
 

--- a/src/c_aci_testing/tools/vn2_get_ip.py
+++ b/src/c_aci_testing/tools/vn2_get_ip.py
@@ -1,0 +1,56 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+import json
+import time
+import sys
+
+from c_aci_testing.utils.run_cmd import run_cmd
+
+
+def vn2_get_ip(deployment_name: str, timeout: int = 300, **kwargs):
+    """
+    Wait for the service load balancer to be ready and return its external IP.
+
+    Args:
+        deployment_name: Name of the deployment/service
+        timeout: Maximum time to wait in seconds (default: 300)
+
+    Returns:
+        str: The external IP of the service
+    """
+    print(f"Waiting for external IP on service/{deployment_name} (timeout: {timeout}s)", file=sys.stderr, flush=True)
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            service_json = run_cmd(["kubectl", "get", "service", deployment_name, "-o", "json"], retries=2, log_run_to=sys.stderr)
+            assert service_json
+            service_data = json.loads(service_json)
+
+            # Check if the service has an external IP assigned
+            external_ip = None
+            if "status" in service_data and "loadBalancer" in service_data["status"]:
+                ingress = service_data["status"]["loadBalancer"].get("ingress", [])
+                if ingress and "ip" in ingress[0]:
+                    external_ip = ingress[0]["ip"]
+
+            if external_ip:
+                print(external_ip, flush=True)
+                return external_ip
+
+            time.sleep(5)
+
+        except Exception as e:
+            if "NotFound" in str(e):
+                print(f"Service {deployment_name} not found, waiting...", file=sys.stderr, flush=True)
+                time.sleep(5)
+            else:
+                print(f"Error retrieving service information: {e}", file=sys.stderr, flush=True)
+                time.sleep(5)
+
+    print(f"service/{deployment_name} did not get an external IP within {timeout} seconds.", file=sys.stderr, flush=True)
+    sys.exit(1)

--- a/src/c_aci_testing/tools/vn2_logs.py
+++ b/src/c_aci_testing/tools/vn2_logs.py
@@ -1,0 +1,18 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from c_aci_testing.utils.run_cmd import run_cmd
+
+
+def vn2_logs(deployment_name: str, follow: bool = False, **kwargs):
+
+    label_selector = f"app={deployment_name}"
+    args = ["kubectl", "logs", "--all-containers", "-l", label_selector, "--tail=-1"]
+    if follow:
+        args.append("-f")
+
+    run_cmd(args, retries=2, consume_stdout=False)

--- a/src/c_aci_testing/tools/vn2_policygen.py
+++ b/src/c_aci_testing/tools/vn2_policygen.py
@@ -1,0 +1,64 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import subprocess
+import sys
+import os
+
+from c_aci_testing.utils.find_bicep import find_bicep_files
+
+
+def vn2_policygen(
+    target_path: str,
+    yaml_path: str,
+    policy_type: str,
+    fragments_json: str | None = None,
+    infrastructure_svn: int | None = None,
+    **kwargs,
+):
+    bicep_file_path, _ = find_bicep_files(target_path)
+    bicep_file_name = re.sub(r"\.bicep$", "", os.path.basename(bicep_file_path))
+
+    if not yaml_path:
+        yaml_path = os.path.join(target_path, f"{bicep_file_name}.yaml")
+
+    rego_output_path = Path(target_path) / f"{bicep_file_name}.rego"
+
+    print("Calling acipolicygen and saving policy to file")
+    subprocess.run(["az", "extension", "add", "--name", "confcom", "--yes"], check=True)
+    args = [
+        "az",
+        "confcom",
+        "acipolicygen",
+        "--virtual-node-yaml",
+        yaml_path,
+        *(["--debug-mode"] if policy_type == "debug" else []),
+        *(["--include-fragments", "--fragments-json", fragments_json] if fragments_json else []),
+        *(["--infrastructure-svn", str(infrastructure_svn)] if infrastructure_svn is not None else []),
+        "--outraw-pretty-print",
+    ]
+    print("Running: " + " ".join(args), flush=True)
+    sys.stderr.flush()
+    res = subprocess.run(
+        args,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    policy = res.stdout.decode()
+    with open(rego_output_path, "wt") as f:
+        f.write(policy)
+    print(f"Policy written to {rego_output_path}")
+
+    args.pop()  # remove --outraw-pretty-print
+    sys.stderr.flush()
+    subprocess.run(
+        args,
+        check=True,
+    )
+    print(f"Policy applied to {yaml_path}")

--- a/src/c_aci_testing/tools/vn2_remove.py
+++ b/src/c_aci_testing/tools/vn2_remove.py
@@ -1,0 +1,103 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from __future__ import annotations
+import subprocess
+import time
+import json
+import sys
+
+from c_aci_testing.utils.run_cmd import run_cmd
+
+def vn2_remove(deployment_name: str, **kwargs):
+    """
+    Remove a VN2 deployment and verify that all pods are cleaned up.
+    """
+    print(f"Removing VN2 deployment: {deployment_name}")
+
+    # First, get the pod label selector for monitoring
+    try:
+        deployment_json = run_cmd(["kubectl", "get", "deployment", deployment_name, "-o", "json"], retries=2)
+        deployment_data = json.loads(deployment_json)
+        label_selector_obj = deployment_data["spec"]["selector"]["matchLabels"]
+        label_selector = ",".join([f"{k}={v}" for k, v in label_selector_obj.items()])
+        print(f"Label selector: {label_selector}")
+    except subprocess.CalledProcessError:
+        print(f"Warning: Couldn't get label selector for deployment {deployment_name}. Deployment might not exist.")
+        label_selector = f"app={deployment_name}"
+        print(f"Using default label selector: {label_selector}")
+
+    # Delete the deployment using kubectl
+    try:
+        print(f"Deleting deployment {deployment_name}")
+        result = subprocess.run(
+            ["kubectl", "delete", f"deployments/{deployment_name}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        if result.returncode != 0:
+            if "NotFound" in result.stderr:
+                print(f"Deployment {deployment_name} not found. It may have been already deleted.")
+            else:
+                print(result.stdout)
+                print(result.stderr)
+                print(f"Error deleting deployment {deployment_name}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error deleting deployment: {str(e)}")
+        sys.exit(1)
+
+    def check_has_pods(verbose=False):
+        """Check if any pods with the deployment label still exist."""
+        try:
+            pods_json = run_cmd(
+                ["kubectl", "get", "pods", "-l", label_selector, "-o", "json"]
+            )
+            pods_data = json.loads(pods_json)
+            has_pods = False
+            not_deleted_states = ["Running", "Pending", "ContainerCreating", "Terminating"]
+            for pod in pods_data.get("items", []):
+                pod_name = pod["metadata"]["name"]
+                status = pod.get("status", {}).get("phase", "Unknown")
+                conditions = pod.get("status", {}).get("conditions", [])
+                all_condition_types = [
+                    condition.get("type", "???")
+                    for condition in sorted(
+                        conditions, key=lambda x: x.get("lastTransitionTime")
+                    )
+                ]
+                start_time = pod.get("status", {}).get("startTime", "???")
+                print(
+                    f"Pod {pod_name} - Status: {status}, Start Time: {start_time}"
+                )
+                print(f"  Conditions: {', '.join(all_condition_types)}")
+                if status in not_deleted_states:
+                    has_pods = True
+                    if verbose:
+                        print("Pod not deleted - info dump follows:\n")
+                        subprocess.run(["kubectl", "describe", "pod", pod_name])
+                else:
+                    print("Pod exists but status is not running - ignoring.")
+            return has_pods
+        except subprocess.CalledProcessError:
+            print("Error checking for pods. This might mean they're already gone.")
+            return False
+
+    # Wait for all pods to be deleted (timeout after 5 minutes)
+    start = time.time()
+    print("Waiting for all pods to be deleted...")
+    while time.time() - start < 300:  # 5 minutes timeout
+        has_pods = check_has_pods()
+        if not has_pods:
+            print("No pods left, deletion successful.")
+            return
+        time.sleep(20)
+
+    # If we get here, the pods weren't deleted within the timeout period
+    check_has_pods(verbose=True)
+    print("Warning: Some pods may still exist after timeout period.")
+    sys.exit(1)

--- a/src/c_aci_testing/utils/acr.py
+++ b/src/c_aci_testing/utils/acr.py
@@ -1,0 +1,62 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+import subprocess
+import json
+import time
+
+azurecr_io_suffix = ".azurecr.io"
+
+
+def strip_acr_suffix(registry: str) -> str | None:
+    """
+    Strips the ".azurecr.io" suffix from the registry name if present, or return None if this is not an ACR registry.
+    """
+
+    if "." in registry and not registry.endswith(azurecr_io_suffix):
+        return None
+
+    if registry.endswith(azurecr_io_suffix):
+        return registry[: -len(azurecr_io_suffix)]
+
+    return registry
+
+
+def get_acr_token(registry: str) -> str:
+    registry_name = strip_acr_suffix(registry)
+    if not registry_name:
+        raise ValueError("Registry is not ACR")
+
+    tries = 0
+    while tries < 5:
+        try:
+            res = subprocess.run(
+                ["az", "acr", "login", "-n", registry_name, "--expose-token"],
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+            return json.loads(res.stdout)["accessToken"]
+        except subprocess.CalledProcessError:
+            tries += 1
+            time.sleep(1)
+    raise Exception("Failed to get ACR token in 5 tries")
+
+
+def login_with_retry(registry: str):
+    attempts = 0
+    max_attempts = 3
+    while attempts < max_attempts:
+        try:
+            subprocess.run(["az", "acr", "login", "--name", registry], check=True)
+            return
+        except subprocess.CalledProcessError:
+            attempts += 1
+            if attempts == max_attempts:
+                print(f"Failed to login to {registry} after {max_attempts} attempts.")
+                raise
+            else:
+                sleep_s = 2 ** (attempts + 1)
+                print(f"Retrying login to {registry} in {sleep_s}s...")
+                time.sleep(sleep_s)

--- a/src/c_aci_testing/utils/arm_expression.py
+++ b/src/c_aci_testing/utils/arm_expression.py
@@ -1,0 +1,122 @@
+#   ---------------------------------------------------------------------------------
+#   Copyright (c) Microsoft Corporation. All rights reserved.
+#   Licensed under the MIT License. See LICENSE in project root for information.
+#   ---------------------------------------------------------------------------------
+
+from typing import Any, List, Callable
+import json
+
+"""
+This is a bit complicated and also not fully correct (it does not handle escape
+sequences in strings, does not handle member functions like
+storageAccount.listKeys()), etc.  But for us it's good enough, and crucially,
+easy to add more functions to should the need arise in the future.
+
+I have attempted to find a Python implementation of the ARM expression parser,
+but did not find anything satisfactory.  There is an official C# implementation
+tho.
+"""
+
+debug = False
+
+def evaluate_expr(expr: str, _handle_func: Callable[[str, List[Any]], Any]) -> Any:
+    """
+    For simplicity, we assume expressions are of the form:
+        functionName '(' arg ',' arg ',' ... ')' [ '.' property '.' property ... ] |
+        \' string \' |
+        number |
+        true | false | null
+    i.e. no things like func(a, b).member_func(c, d) or a.func()
+    We also assume strings never contains ' in them
+    """
+
+    orig_expr = expr
+
+    expr = expr.strip()
+
+    try:
+        if expr.startswith("'") and expr.endswith("'"):
+            return expr[1:-1]
+        if expr.startswith('"') and expr.endswith('"'):
+            return expr[1:-1]
+        if expr == "true":
+            return True
+        if expr == "false":
+            return False
+        if expr == "null":
+            return None
+        if expr.isdigit():
+            return int(expr)
+
+        def _find_next_unenclosed(
+            s: str, start: int, char: str, open_chars: str, close_chars: str, pair_chars: str
+        ) -> int:
+            """
+            Find the next occurrence of char in s, starting from start, that is
+            not enclosed in any pair of (open_chars, close_chars), ignoring occurrence within pair_chars.
+
+            Example:
+                _find_next_unenclosed("a(b(c,'d))',e),f), g", 1, "), "(", ")", "'") == 16
+            """
+            depth = 0
+            pair_opened = False
+            for i in range(start, len(s)):
+                if s[i] == char and depth == 0 and not pair_opened:
+                    return i
+                elif s[i] in pair_chars:
+                    pair_opened = not pair_opened
+                elif s[i] in open_chars and not pair_opened:
+                    depth += 1
+                elif s[i] in close_chars and not pair_opened:
+                    depth -= 1
+            return -1
+
+        assert _find_next_unenclosed("a(b(c,'d))',e),f), g", 2, ")", "(", ")", "'") == 16
+
+        result = None
+        if "(" in expr:
+            # do function call
+            param_start = expr.find("(")
+            param_end = _find_next_unenclosed(expr, param_start + 1, ")", "(", ")", "'")
+            if param_end == -1:
+                raise ValueError(f"Failed to find matching ')' for function call")
+            function_name = expr[:param_start]
+            if not function_name.isalnum():
+                raise ValueError(f"Invalid function name: {function_name}")
+            param_list_str = expr[param_start + 1 : param_end]
+            param_list = []
+            i = 0
+            while i < len(param_list_str):
+                next_comma = _find_next_unenclosed(param_list_str, i, ",", "(", ")", "'")
+                if next_comma == -1:
+                    param_list.append(param_list_str[i:].strip())
+                    break
+                param_list.append(param_list_str[i:next_comma].strip())
+                i = next_comma + 1
+            result = _handle_func(function_name, [evaluate_expr(p, _handle_func) for p in param_list])
+            expr = expr[param_end + 1 :].strip()
+        else:
+            raise ValueError(f"Expected to find a function call at expression root")
+
+        # Handle property access
+        while expr.startswith("."):
+            prop_end = expr.find(".", 1)
+            if prop_end == -1:
+                prop_end = len(expr)
+            prop_name = expr[1:prop_end]
+            if not prop_name:
+                raise ValueError(f"Failed to parse property access")
+            assert isinstance(result, dict)
+            if prop_name not in result:
+                raise ValueError(f"could not find property '{prop_name}'")
+            result = result[prop_name]
+            expr = expr[prop_end + 1 :].strip()
+
+        if expr:
+            raise ValueError(f"Unexpected trailing string: {expr}")
+
+        if debug:
+            print(f"Evaluated expression '{orig_expr}' to {json.dumps(result)}", flush=True)
+        return result
+    except ValueError as e:
+        raise ValueError(f"Failed to parse expression '{orig_expr}': {e}")

--- a/src/c_aci_testing/utils/arm_expression.py
+++ b/src/c_aci_testing/utils/arm_expression.py
@@ -118,5 +118,5 @@ def evaluate_expr(expr: str, _handle_func: Callable[[str, List[Any]], Any]) -> A
         if debug:
             print(f"Evaluated expression '{orig_expr}' to {json.dumps(result)}", flush=True)
         return result
-    except ValueError as e:
+    except Exception as e:
         raise ValueError(f"Failed to parse expression '{orig_expr}': {e}")

--- a/src/c_aci_testing/utils/find_bicep.py
+++ b/src/c_aci_testing/utils/find_bicep.py
@@ -1,0 +1,33 @@
+from typing import Tuple
+import os
+
+# This has to be a separate module to avoid circular imports
+
+
+def find_bicep_files(
+    target_path: str,
+) -> Tuple[str, str]:
+    """
+    Returns (bicep_file_path, bicepparam_file_path)
+    """
+
+    bicep_file_path = None
+    bicepparam_file_path = None
+
+    # Find the bicep files
+    for file in os.listdir(target_path):
+        if file.endswith(".bicep"):
+            if bicep_file_path:
+                raise ValueError("Multiple .bicep files found in the target directory.")
+            bicep_file_path = os.path.join(target_path, file)
+        elif file.endswith(".bicepparam"):
+            if bicepparam_file_path:
+                raise ValueError("Multiple .bicepparam files found in the target directory.")
+            bicepparam_file_path = os.path.join(target_path, file)
+
+    if not bicep_file_path:
+        raise FileNotFoundError(f"No bicep file found in {target_path}")
+    if not bicepparam_file_path:
+        raise FileNotFoundError(f"No bicepparam file found in {target_path}")
+
+    return bicep_file_path, bicepparam_file_path

--- a/src/c_aci_testing/utils/parse_bicep.py
+++ b/src/c_aci_testing/utils/parse_bicep.py
@@ -102,7 +102,20 @@ def _resolve_arm_functions(
                 obj[key] = value
             return obj
         else:
-            raise ValueError(f"Unknown function: {func_name}")
+            ret_str = f"{func_name}("
+            first = True
+            for arg in args:
+                if first:
+                    first = False
+                else:
+                    ret_str += ","
+                if isinstance(arg, str):
+                    ret_str += f"'{arg}'"
+                else:
+                    ret_str += repr(arg)
+            ret_str += ")"
+            print(f"Warning: Unknown function: {ret_str}", file=sys.stderr, flush=True)
+            return ret_str
 
     def _resolve_val(val: Any) -> Any:
         if isinstance(val, str) and val.startswith("[") and val.endswith("]"):

--- a/src/c_aci_testing/utils/parse_bicep.py
+++ b/src/c_aci_testing/utils/parse_bicep.py
@@ -9,9 +9,83 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
+import re
 from typing import Iterable, Tuple
 
 from c_aci_testing.tools.aci_param_set import aci_param_set
+from c_aci_testing.utils.find_bicep import find_bicep_files
+
+
+def resolve_arm_functions(arm_template_str, resource_group, subscription, deployment_name):
+
+    # Handle constants
+    for constant, value in [
+        ("resourceGroup().name", resource_group),
+        ("subscription().subscriptionId", subscription),
+        ("deployment().name", deployment_name),
+    ]:
+        arm_template_str = arm_template_str.replace(constant, value)
+
+    # Remove the square brackets which denote functions in ARM templates
+    # since they will be resolved. Do it here so parameters are correctly resolved.
+    arm_template_lines = arm_template_str.split("\\n")
+    for idx, line in enumerate(arm_template_lines):
+        arm_template_lines[idx] = re.sub(r'\\"\[(.*?)\]\\"', r"\"\1\"", line)
+    arm_template_str = "\\n".join(arm_template_lines)
+    arm_template_dict = json.loads(json.loads(arm_template_str)["templateJson"])
+
+    # Handle parameters function
+    parameters_dict = {
+        key: value["value"]
+        for key, value in json.loads(json.loads(arm_template_str)["parametersJson"])["parameters"].items()
+    }
+    parameters = {key: definition.get("defaultValue") for key, definition in arm_template_dict["parameters"].items()}
+    parameters.update(parameters_dict)
+    for key, value in parameters.items():
+        arm_template_str = re.sub(
+            f"parameters\\('{key}'\\)",
+            str(value),
+            arm_template_str,
+        )
+
+    # Handle empty function
+    arm_template_lines = arm_template_str.split("\\n")
+    for idx, line in enumerate(arm_template_lines):
+        for match in re.findall(r"empty\((.*?)\)", line):
+            arm_template_lines[idx] = line.replace(
+                f"empty({match})",
+                "true" if match == "" else "false",
+            )
+            line = arm_template_lines[idx]
+    arm_template_str = "\\n".join(arm_template_lines)
+
+    # Handle if function
+    arm_template_lines = arm_template_str.split("\\n")
+    for idx, line in enumerate(arm_template_lines):
+        for condition, if_true, if_false in re.findall(
+            r"if\((.*?)\, (.*?)\, (.*?)\)",
+            line,
+        ):
+            arm_template_lines[idx] = line.replace(
+                f"if({condition}, {if_true}, {if_false})",
+                f"{if_true}" if condition == "true" else f"{if_false}",
+            )
+            line = arm_template_lines[idx]
+    arm_template_str = "\\n".join(arm_template_lines)
+
+    # Handle format function
+    arm_template_lines = arm_template_str.split("\\n")
+    for idx, line in enumerate(arm_template_lines):
+        for format_string, inputs in re.findall(r"format\((.*?)\, (.*?)\)", line):
+            inputs_list = [i.strip("'") for i in inputs.split(", ")]
+            arm_template_lines[idx] = line.replace(
+                f"format({format_string}, {inputs})",
+                format_string.format(*inputs_list).strip("'"),
+            )
+    arm_template_str = "\\n".join(arm_template_lines)
+
+    return json.loads(json.loads(arm_template_str)["templateJson"])
 
 
 def parse_bicep(
@@ -20,24 +94,14 @@ def parse_bicep(
     resource_group: str,
     deployment_name: str,
     registry: str,
-    repository: str,
-    tag: str,
-) -> Iterable[Tuple[str, dict, Iterable[dict]]]:
+    repository: str | None,
+    tag: str | None,
+) -> dict:
+    """
+    Returns ARM template JSON with parameters inlined
+    """
 
-    bicep_file_path = None
-    bicepparam_file_path = None
-
-    # Find the bicep files
-    for file in os.listdir(target_path):
-        if file.endswith(".bicep"):
-            bicep_file_path = os.path.join(target_path, file)
-        elif file.endswith(".bicepparam"):
-            bicepparam_file_path = os.path.join(target_path, file)
-
-    if not bicep_file_path:
-        raise FileNotFoundError(f"No bicep file found in {target_path}")
-    if not bicepparam_file_path:
-        raise FileNotFoundError(f"No bicepparam file found in {target_path}")
+    _, bicepparam_file_path = find_bicep_files(target_path)
 
     # Set required parameters in bicep param file
     aci_param_set(
@@ -53,52 +117,75 @@ def parse_bicep(
         add=False,  # If the user removed a field, don't re-add it
     )
 
-    # Create an ARM template with parameters resolved
-    print("Resolving parameters using what-if deployment")
+    print("Converting bicep files to an ARM template", flush=True)
+    sys.stderr.flush()
     res = subprocess.run(
         [
             "az",
-            "deployment",
-            "group",
-            "what-if",
-            "--name",
-            deployment_name,
-            "--no-pretty-print",
-            "--mode",
-            "Complete",
-            "--subscription",
-            subscription,
-            "--resource-group",
-            resource_group,
-            "--template-file",
-            bicep_file_path,
-            "--parameters",
+            "bicep",
+            "build-params",
+            "--file",
             bicepparam_file_path,
+            "--stdout",
         ],
         check=True,
         stdout=subprocess.PIPE,
     )
+    arm_template_json = resolve_arm_functions(
+        res.stdout.decode(),
+        resource_group=resource_group,
+        subscription=subscription,
+        deployment_name=deployment_name,
+    )
 
-    resolves_json = json.loads(res.stdout)
-    for change in resolves_json["changes"]:
-        result = change.get("after")
-        if result:
-            for prefix in (
-                "providers/Microsoft.ContainerInstance/containerGroups/",
-                "providers/Microsoft.ContainerInstance/containerGroupProfiles/",
-            ):
-                container_group_id = (
-                    result["id"]
-                    .split(prefix)[-1]
-                    .replace(deployment_name, bicep_file_path.split("/")[-1].split(".")[0])
-                    .replace("-", "_")
-                )
+    return arm_template_json
 
-                if prefix in result["id"]:
 
-                    def get_containers(group):
-                        if "containers" in group["properties"]:
-                            for container in group["properties"]["containers"]:
-                                yield container
+def arm_template_for_each_container_group(
+    arm_template_json: dict,
+) -> Iterable[Tuple[dict, Iterable[dict]]]:
+    """
+    Return an iterater of tuples:
+        (container_group_resource_json, containers)
+    where:
+        - container_group_resource_json is the ARM JSON for a container group
+        - containers is an iterable of the containers in the container group
+    """
 
-                    yield container_group_id, result, get_containers(result)
+    for resource in arm_template_json["resources"]:
+        # Only handle container groups
+        if resource["type"] not in (
+            "Microsoft.ContainerInstance/containerGroups",
+            "Microsoft.ContainerInstance/containerGroupProfiles",
+        ):
+            continue
+
+        def get_containers(group) -> Iterable[dict]:
+            if "containers" in group["properties"]:
+                for container in group["properties"]["containers"]:
+                    yield container
+
+        yield resource, get_containers(resource)
+
+
+def arm_template_for_each_container_group_with_fixup(
+    arm_template_json: dict,
+) -> Iterable[Tuple[dict, Iterable[dict]]]:
+    """
+    Same interface as arm_template_for_each_container_group, but with some
+    acipolicygen workarounds
+    """
+
+    for resource, containers in arm_template_for_each_container_group(arm_template_json):
+
+        containers = list(containers)
+
+        # Workaround for acipolicygen not supporting empty environment variables
+        for container in containers:
+            for env_var in container["properties"].get("environmentVariables", []):
+                if "value" in env_var and env_var["value"] == "":
+                    del env_var["value"]
+                if "value" not in env_var:
+                    env_var["secureValue"] = ""
+
+        yield resource, containers

--- a/src/c_aci_testing/utils/run_cmd.py
+++ b/src/c_aci_testing/utils/run_cmd.py
@@ -1,12 +1,15 @@
 from typing import List, Optional
 import subprocess
 import time
+import sys
 
 
-def run_cmd(cmd: List[str], retries: int = 0, consume_stdout: bool = True) -> Optional[str]:
+def run_cmd(cmd: List[str], retries: int = 0, consume_stdout: bool = True, log_run_to=sys.stdout) -> Optional[str]:
     retried_times = 0
     while True:
-        print(f"Running command: {' '.join(cmd)}")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        print(f"Running command: {' '.join(cmd)}", file=log_run_to, flush=True)
         try:
             run_res = subprocess.run(cmd, stdout=subprocess.PIPE if consume_stdout else None, text=True, check=True)
             if consume_stdout:

--- a/src/c_aci_testing/utils/run_cmd.py
+++ b/src/c_aci_testing/utils/run_cmd.py
@@ -1,0 +1,21 @@
+from typing import List, Optional
+import subprocess
+import time
+
+
+def run_cmd(cmd: List[str], retries: int = 0, consume_stdout: bool = True) -> Optional[str]:
+    retried_times = 0
+    while True:
+        print(f"Running command: {' '.join(cmd)}")
+        try:
+            run_res = subprocess.run(cmd, stdout=subprocess.PIPE if consume_stdout else None, text=True, check=True)
+            if consume_stdout:
+                return run_res.stdout.strip()
+            return None
+        except subprocess.CalledProcessError as e:
+            print(f"Command failed with code: {e.returncode}")
+            retried_times += 1
+            if retried_times <= retries:
+                time.sleep(5)
+            else:
+                raise


### PR DESCRIPTION
```
(.venv) (1m13s) tingmao-laptop (mao; tingmao/vn2-more-tests; 4) (vn2-aks-westeurope/default) ~/s/c/w/thim
> c-aci-testing vn2 generate_yaml .
Setting parameter 'managedIDName' to 'cacidashboard'
Setting parameter 'registry' to 'cacidashboard.azurecr.io'
Setting parameter 'repository' to ''
Setting parameter 'tag' to '2.9'
Converting bicep files to an ARM template
WARNING: A new Bicep release is available: v0.34.44. Upgrade now by running "az bicep upgrade".
(.venv) (5.159s) tingmao-laptop (mao; tingmao/vn2-more-tests; 5) (vn2-aks-westeurope/default) ~/s/c/w/thim
> c-aci-testing vn2 policygen .
Calling acipolicygen and saving policy to file
Extension 'confcom' 1.2.1 is already installed.
Running: az confcom acipolicygen --virtual-node-yaml /home/mao/confidential-aci-dashboard/workloads/thim/thim.yaml --outraw-pretty-print
WARNING: Secrets that are included in the provided arm template or configuration files in the container env or cmd sections will be printed out with this flag. These are outputed secrets that you must protect. Be sure that you do not include these secrets in your source control. Also verify that no secrets are present in the logs of your command or script. For additional information, see http://aka.ms/clisecrets. 

WARNING: Generating security policy for Input File: /home/mao/confidential-aci-dashboard/workloads/thim/thim.yaml in clear text
Pulling and hashing images...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.14s/percent]
WARNING: Using local version of mcr.microsoft.com/aci/skr:2.9. It may differ from the remote image
Policy written to /home/mao/confidential-aci-dashboard/workloads/thim/thim.rego
Generating security policy for Input File: /home/mao/confidential-aci-dashboard/workloads/thim/thim.yaml in base64
Pulling and hashing images...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.36percent/s]
Using local version of mcr.microsoft.com/aci/skr:2.9. It may differ from the remote image
Do you want to overwrite the Base64 Policy currently in workload 'Workload 0'? (y/n) Y
be1ae3ce97973fada4f519e5c51a8e5e79c8e58888e2704a13f9bc81a8c1f277
Policy applied to /home/mao/confidential-aci-dashboard/workloads/thim/thim.yaml
(.venv) (13.684s) tingmao-laptop (mao; tingmao/vn2-more-tests; 6) (vn2-aks-westeurope/default) ~/s/c/w/thim
> c-aci-testing vn2 deploy .
Deployment name: tingmao-thim
Label selector: app=tingmao-thim
Number of replicas: 1
Running command: kubectl apply -f /home/mao/confidential-aci-dashboard/workloads/thim/thim.yaml
deployment.apps/tingmao-thim created
Waiting for pods to be in Running state...
...
Running command: kubectl get pods -l app=tingmao-thim -o json
Pod tingmao-thim-bbcfcdbb9-h5p64 status: Running
  Conditions: Initialized, PodScheduled, PodReadyToStartContainers, Ready, ContainersReady
  Container primary:
    ID: virtualcri://pods/4cb7c7ab-50a2-407f-9e47-b2d0c4ffa680/attempts/0/sandboxes/caas-b2d48c444d0848c2bd792aebc64db924-fc05e3d7ed4635e002fdf1fa3d78e951cc94aace6e0ac88be706a2bfe6391f43/containers/3f34316fc05d82e3146e9bd8a98b94f8ed97225d2dd3e757ae08a42156ab6d6d
    Image ID: mcr.microsoft.com/aci/skr@sha256:8b25d43606e82e2ffec09f445520b12bd99bb7474af2e1949b3594882662ccee
    Restart Count: 0
All pods are running now.
VN2 deployment successful: tingmao-thim
All pods are running. You can monitor them by using the 'vn2 logs' command.
(.venv) (49.84s) tingmao-laptop (mao; tingmao/vn2-more-tests; 6) (vn2-aks-westeurope/default) ~/s/c/w/thim
> c-aci-testing vn2 logs
Running command: kubectl logs --all-containers -l app=tingmao-thim --tail=-1
Provided UVM_SECURITY_CONTEXT_DIR=/security-context-3771017092
ls /security*:
drwxr-xr-x   2 root root    93 Mar 28 14:00 security-context-3771017092
total 40
drwxr-xr-x 2 root root    93 Mar 28 14:00 .
drwxr-xr-x 1 root root    63 Mar 28 14:00 ..
-rwxr--r-- 1 root root  8908 Mar 28 14:00 host-amd-cert-base64
-rwxr--r-- 1 root root 14464 Mar 28 14:00 reference-info-base64
-rwxr--r-- 1 root root 11232 Mar 28 14:00 security-policy-base64
...
```

TODO:
- [x] support deploying a load balancer and returning IP
- [ ] continuous monitoring
