### PR TITLE
fix: Remove pyspark from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,6 @@ dependencies = [
 c-aci-testing = "c_aci_testing.main:main"
 
 [project.optional-dependencies]
-spark = [
-    "pyspark>=3.0.0"
-]
 test = [
     "bandit[toml]==1.7.9",
     "black==24.4.2",


### PR DESCRIPTION
We do not seem to make any use of this, and it slows down every install of c-aci-testing by a bit.