### PR TITLE
fix: Update the allow all rego policy to use api_version instead of api_svn

### DIFF
--- a/src/c_aci_testing/templates/allow_all_policy.rego
+++ b/src/c_aci_testing/templates/allow_all_policy.rego
@@ -1,6 +1,6 @@
 package policy
 
-api_svn := "0.10.0"
+api_version := "0.10.0"
 
 mount_device := {"allowed": true}
 mount_overlay := {"allowed": true}


### PR DESCRIPTION
`api_svn` is the old name.