### PR TITLE
fix: {aci, vm} remove: Assume default names when deployment is missing

### DIFF
--- a/src/c_aci_testing/tools/aci_remove.py
+++ b/src/c_aci_testing/tools/aci_remove.py
@@ -16,8 +16,20 @@ def aci_remove(
     resource_group: str,
     **kwargs,
 ):
-    for id in aci_get_ids(deployment_name, subscription, resource_group):
+    resources = aci_get_ids(deployment_name, subscription, resource_group)
+
+    if not resources:
+        print(
+            f"Failed to get deployment output. Removing any container group of the same name as the deployment: {deployment_name}"
+        )
+        resources = [
+            f"/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.ContainerInstance/containerGroups/{deployment_name}"
+        ]
+
+    for id in resources:
         group_name = id.split("/")[-1]
+        # az resource delete will return successfully even if the resource does
+        # not exist.
         subprocess.run([
             "az", "resource", "delete", "--no-wait",
             "--subscription", subscription,

--- a/src/c_aci_testing/tools/vm_remove.py
+++ b/src/c_aci_testing/tools/vm_remove.py
@@ -18,6 +18,12 @@ def vm_remove(
 ):
     remaining_resources = set(vm_get_ids(deployment_name, subscription, resource_group))
 
+    if not remaining_resources:
+        print(f"Failed to get deployment output. Using default VM name: {deployment_name}-vm")
+        remaining_resources = {
+            f"/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Compute/virtualMachines/{deployment_name}-vm"
+        }
+
     while remaining_resources:
         print(f"Deleting {len(remaining_resources)} resources...")
 


### PR DESCRIPTION
See for example
https://github.com/microsoft/confidential-aci-dashboard/actions/runs/15839843871/job/44650401615 In this deployment, the resource was not cleaned up since the deployment itself has already disappeared (likely Azure timeout).  We still want to clean up any underlying resources, so we assume it's using the default naming scheme.