### PR TITLE
fix: vm_generate_scripts: Only make container privileged if requested

### DIFF
--- a/src/c_aci_testing/templates/lcow_configs/container.json.template
+++ b/src/c_aci_testing/templates/lcow_configs/container.json.template
@@ -7,7 +7,6 @@
     },
     "linux": {
         "security_context": {
-            "privileged": true
         }
     },
     "annotations" : {

--- a/src/c_aci_testing/templates/lcow_configs/container_group.json.template
+++ b/src/c_aci_testing/templates/lcow_configs/container_group.json.template
@@ -6,7 +6,6 @@
     },
     "linux": {
         "security_context": {
-            "privileged": true
         }
     },
     "annotations": {


### PR DESCRIPTION
When a proper policy is used, we can't start it privileged if the policy doesn't allow it.  This fix avoids bogus policy denials.