### PR TITLE
feat: Print out UID of pod during vn2 deployment

### DIFF
--- a/src/c_aci_testing/tools/vn2_deploy.py
+++ b/src/c_aci_testing/tools/vn2_deploy.py
@@ -192,6 +192,7 @@ def vn2_deploy(target_path: str, yaml_path: str, monitor_duration_secs: int, dep
         nb_good_pod = 0
         for pod in sorted(pods_data["items"], key=lambda x: x["metadata"]["name"]):
             print(f"Pod {pod['metadata']['name']} status: {pod['status']['phase']}")
+            print(f"  Uid: {pod['metadata'].get('uid', '???')}")
             pod_print_conditions(pod)
             sys.stdout.flush()
             if pod.get("status", {}).get("phase") == "Running":
@@ -246,6 +247,7 @@ def vn2_deploy(target_path: str, yaml_path: str, monitor_duration_secs: int, dep
                 f"Pod {pod_name} - Status: {status}, Start Time: {start_time}",
                 file=out_buf,
             )
+            print(f"  Uid: {pod['metadata'].get('uid', '???')}", file=out_buf)
             pod_print_conditions(pod, out_buf)
             if status != "Running":
                 print(f"  !: Status is not running!", file=out_buf)


### PR DESCRIPTION
When things go wrong, we may not get a container ID printout, but the container group is always the pod UID plus "_0".  By printing the pod UID, we makes it easier to diagnose issues after the fact.

This UID is available as soon as the pod creation request is accepted by k8s:

    Waiting for pods to be in Running state...
    Running command: kubectl get pods -l app=test -o json
    Pod test-bf6545c76-9fvh5 status: Pending
    Uid: da2d4760-78b5-4c46-9fe2-36e9c8fcd2f5
    Conditions: PodReadyToStartContainers, Initialized, Ready, ContainersReady, PodScheduled

Using this, one can simply search in the Azure portal for the in-progress container group, or search for why a container creation failed in the vn2 logs.